### PR TITLE
Add eth explorer api client.

### DIFF
--- a/.env
+++ b/.env
@@ -35,3 +35,4 @@ ENABLE_COMMUNITY_MEMBER_NFT=enable_community_member_nft
 ENABLE_THE_GRAPH_JOBS=enable_the_graph_jobs
 ENABLE_VIRAL_LOOPS_API=enable_viral_loops_api
 VIRAL_LOOPS_API_KEY=viral_loops_api_key
+ETH_EXPLORER_API_KEY=eth_plorer_api_key

--- a/lib/eth_explorer/client.rb
+++ b/lib/eth_explorer/client.rb
@@ -1,0 +1,36 @@
+require "eth_explorer/response"
+
+module EthExplorer
+  BASE_URL = "https://api.ethplorer.io"
+
+  TOKEN_INFO_URL = "#{BASE_URL}/getTokenInfo"
+  TOKEN_HOLDERS_URL = "#{BASE_URL}/getTopTokenHolders"
+
+  class Client
+    def token_info(token_address:)
+      Response.new(
+        http_response: Faraday.get(
+          "#{TOKEN_INFO_URL}/#{token_address}",
+          base_params
+        )
+      )
+    end
+
+    def token_holders(token_address:)
+      Response.new(
+        http_response: Faraday.get(
+          "#{TOKEN_HOLDERS_URL}/#{token_address}",
+          base_params.merge(limit: 1000)
+        )
+      )
+    end
+
+    private
+
+    def base_params
+      {
+        apiKey: ENV.fetch("ETH_EXPLORER_API_KEY")
+      }
+    end
+  end
+end

--- a/lib/eth_explorer/response.rb
+++ b/lib/eth_explorer/response.rb
@@ -1,0 +1,25 @@
+module EthExplorer
+  class Response
+    def initialize(http_response:)
+      @http_response = http_response
+    end
+
+    attr_reader :http_response
+
+    def ok?
+      http_response.status >= 200 && http_response.status < 300
+    end
+
+    def success?
+      ok?
+    end
+
+    def result
+      return unless ok?
+
+      JSON.parse(body)
+    end
+
+    delegate :body, to: :http_response
+  end
+end

--- a/spec/eth_explorer/client_spec.rb
+++ b/spec/eth_explorer/client_spec.rb
@@ -1,0 +1,114 @@
+require "rails_helper"
+require "eth_explorer/client"
+
+RSpec.shared_examples "an unsuccesful response" do
+  it "returns an not OK response" do
+    expect(request).not_to be_ok
+  end
+
+  it "returns an empty result" do
+    expect(request.result).to be_nil
+  end
+end
+
+RSpec.describe EthExplorer::Client do
+  let(:token_address) { SecureRandom.hex }
+
+  let(:response) do
+    OpenStruct.new(status: response_status, body: response_body)
+  end
+
+  let(:response_status) { 200 }
+  let(:response_body) { nil }
+
+  let(:api_key) { "test_api_key" }
+
+  before do
+    allow(Faraday).to receive(:get).and_return(response)
+
+    ENV["ETH_EXPLORER_API_KEY"] = api_key
+  end
+
+  describe "#token_info" do
+    let(:request_url) { EthExplorer::TOKEN_INFO_URL + "/#{token_address}" }
+    let(:response_body) { File.read("spec/fixtures/eth_explorer/token_info.json") }
+
+    subject(:get_token_info) do
+      described_class.new.token_info(token_address: token_address)
+    end
+
+    it "makes a request to the API" do
+      get_token_info
+
+      expect(Faraday).to have_received(:get).with(
+        request_url,
+        {
+          apiKey: api_key
+        }
+      )
+    end
+
+    it "returns a response get_token_info" do
+      expect(get_token_info).to be_a(EthExplorer::Response)
+    end
+
+    it "returns an OK response" do
+      expect(get_token_info).to be_ok
+    end
+
+    it "returns an account user in the response" do
+      expect(get_token_info.result)
+        .to eq(JSON.parse(response_body))
+    end
+
+    context "when the request is unsuccessful" do
+      let(:response_status) { 500 }
+
+      it_behaves_like "an unsuccesful response" do
+        let(:request) { get_token_info }
+      end
+    end
+  end
+
+  describe "#token_holders" do
+    let(:request_url) { EthExplorer::TOKEN_HOLDERS_URL + "/#{token_address}" }
+    let(:response_body) { File.read("spec/fixtures/eth_explorer/token_holders.json") }
+
+    subject(:get_token_holders) do
+      described_class.new.token_holders(token_address: token_address)
+    end
+
+    it "makes a request to the API" do
+      get_token_holders
+
+      expect(Faraday).to have_received(:get).with(
+        request_url,
+        {
+          apiKey: api_key,
+          limit: 1000
+        }
+      )
+    end
+
+    it "returns a response get_token_holders" do
+      expect(get_token_holders).to be_a(EthExplorer::Response)
+    end
+
+    it "returns an OK response" do
+      expect(get_token_holders).to be_ok
+    end
+
+    it "returns an account user in the response" do
+      expect(get_token_holders.result)
+        .to eq(JSON.parse(response_body))
+    end
+
+    context "when the request is unsuccessful" do
+      let(:response_status) { 500 }
+
+      it_behaves_like "an unsuccesful response" do
+        let(:request) { get_token_holders }
+      end
+    end
+  end
+end

--- a/spec/fixtures/eth_explorer/token_holders.json
+++ b/spec/fixtures/eth_explorer/token_holders.json
@@ -1,0 +1,59 @@
+{
+  "holders": [
+      {
+          "address": "0lajs9ihbsakxa32ff8ca08036337fabf50fa029812361cd176c8",
+          "balance": 39830508570,
+          "share": 39.83
+      },
+      {
+          "address": "0lajs9ihbsakxbdeb21edd14f2b8438b0b9f01196e7c23fde1b73",
+          "balance": 38522138357,
+          "share": 38.52
+      },
+      {
+          "address": "0lajs9ihbsakx0390f1390831f8d92c00dec2dab2efd1a5711811",
+          "balance": 9625951738,
+          "share": 9.63
+      },
+      {
+          "address": "0lajs9ihbsakx87c926b07162be81ed2af05e3307a7d4a3f0ade1",
+          "balance": 6500000000,
+          "share": 6.5
+      },
+      {
+          "address": "0lajs9ihbsakx86babeb53683382890890147b714040d3ffb0ee7",
+          "balance": 4671401335,
+          "share": 4.67
+      },
+      {
+          "address": "0lajs9ihbsakxab3c51c6a3f377a3b31b5fbf028971196caf22ef",
+          "balance": 400000000,
+          "share": 0.4
+      },
+      {
+          "address": "0lajs9ihbsakxbe30819e584c0ed313bcce7ae62f1e953952a941",
+          "balance": 340740000,
+          "share": 0.34
+      },
+      {
+          "address": "0lajs9ihbsakxd9bf26d61833431ca85506cf5ea183d32b027b0c",
+          "balance": 90000000,
+          "share": 0.09
+      },
+      {
+          "address": "0lajs9ihbsakx7e79ad45981df73d162ede5b0c8c54263fb220ca",
+          "balance": 10000000,
+          "share": 0.01
+      },
+      {
+          "address": "0lajs9ihbsakx1b78707a5067e26afb3d81440b2db5dd0f71c53f",
+          "balance": 4630000,
+          "share": 0
+      },
+      {
+          "address": "0lajs9ihbsakx9aa73d8693ee3b2d45295e98b1a8626452cc53e1",
+          "balance": 4630000,
+          "share": 0
+      }
+  ]
+}

--- a/spec/fixtures/eth_explorer/token_info.json
+++ b/spec/fixtures/eth_explorer/token_info.json
@@ -1,0 +1,15 @@
+{
+  "address": "0xfdc01e02a12d5ed6f3f9f680dc4kajsd87320230s",
+  "decimals": "8",
+  "name": "TALENT",
+  "symbol": "TALENT",
+  "totalSupply": "100000000000",
+  "transfersCount": 60,
+  "lastUpdated": 1646079423,
+  "issuancesCount": 0,
+  "holdersCount": 500,
+  "ethTransfersCount": 0,
+  "price": false,
+  "owner": "0x",
+  "countOps": 50
+}


### PR DESCRIPTION
## Summary

### What changed?

Added eth explorer api client with a method to get token information and token holders based on a passed contract.

### Why it changed?

We want to import tokens from other networks into the system.

### How it changed?

Added an API client for Ethplorer: https://ethplorer.io/.

Documentation: https://github.com/EverexIO/Ethplorer/wiki/Ethplorer-API

Postman client: https://documenter.getpostman.com/view/3347257/UVyrUbjX

## Notion link

<!--- Link to the Notion task. -->

## How to test?

<!--- instructions on how to test the changes. -->

## Notes

<!--- Notes you might consider worth adding. -->