### PR TITLE
Scout quest should only use talent invites

### DIFF
--- a/app/services/create_user.rb
+++ b/app/services/create_user.rb
@@ -109,7 +109,7 @@ class CreateUser
   def give_reward_to_inviter(invite)
     return unless invite.user
 
-    if invite.user.invites.sum(:uses) > 4
+    if invite.user.invites.where(talent_invite: true).sum(:uses) > 4
       UpdateTasksJob.perform_later(type: "Tasks::Register", user_id: invite.user.id)
     end
   end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -19,4 +19,9 @@ FactoryBot.define do
   factory :notification do
     type { MessageReceivedNotification.name }
   end
+
+  factory :invite do
+    code { SecureRandom.hex(8) }
+    max_uses { 5 }
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -15,6 +15,7 @@ end
 
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require "spec_helper"
+require "sidekiq/testing"
 
 ENV["RAILS_ENV"] ||= "test"
 
@@ -53,6 +54,10 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
 
   ActiveJob::Base.queue_adapter = :test
+
+  config.before(:each) do
+    Sidekiq::Worker.clear_all
+  end
 
   config.before(:each) do |example|
     Capybara.current_driver = JS_DRIVER if example.metadata[:js]

--- a/spec/services/create_user_spec.rb
+++ b/spec/services/create_user_spec.rb
@@ -1,0 +1,53 @@
+require "rails_helper"
+
+RSpec.describe CreateUser do
+  include ActiveJob::TestHelper
+
+  subject(:create_user) { described_class.new }
+
+  let(:user) { create(:user, username: "jack") }
+
+  context "when a valid invite is provided" do
+    let(:invite) { create(:invite, user: user) }
+    let(:user_creation_params) {
+      {
+        email: "francisco@talentprotocol.com",
+        username: "leal",
+        password: "password",
+        invite_code: invite.code,
+        theme_preference: "light"
+      }
+    }
+
+    it "it creates a new user" do
+      result = create_user.call(user_creation_params)
+
+      expect(result[:success]).to be(true)
+      expect(result[:user]).to be_persisted
+    end
+  end
+
+  context "when the invite already has enough uses for the scout reward" do
+    let(:invite) { create(:invite, user: user, talent_invite: true, uses: 4) }
+    let(:user_creation_params) {
+      {
+        email: "francisco@talentprotocol.com",
+        username: "leal",
+        password: "password",
+        invite_code: invite.code,
+        theme_preference: "light"
+      }
+    }
+
+    it "it enqueues the job to calculate rewards" do
+      Sidekiq::Testing.inline! do
+        create_user.call(user_creation_params)
+
+        expect(enqueued_jobs.size).to eq 1
+        job = enqueued_jobs[0]
+        expect(job["arguments"][0]["type"]).to eq("Tasks::Register")
+        expect(job["arguments"][0]["user_id"]).to eq(user.id)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

The Scout Quest should only look at talent invites and not regular invites.