### PR TITLE
30 day market cap improvements

### DIFF
--- a/app/packs/src/components/talent/TalentPage.jsx
+++ b/app/packs/src/components/talent/TalentPage.jsx
@@ -181,7 +181,7 @@ const TalentPage = ({ talents, isAdmin }) => {
               token: { ...result[token.contractId]?.token, ...token },
               marketCap: marketCap || "-1",
               supporterCounter: supporterCounter || "-1",
-              marketCapVariance: marketCapVariance || "-1",
+              marketCapVariance: marketCapVariance || 0,
               ...rest,
             };
 


### PR DESCRIPTION
## Summary

We're displaying -100% when users have 0% market cap variance. This PR fixes this issue.

## Notion link

<!--- Link to the Notion task. -->

## How to test?

<!--- instructions on how to test the changes. -->

## Notes

<!--- Notes you might consider worth adding. -->
