### PR TITLE
Send talent followers count to the ui

### DIFF
--- a/app/blueprints/talent_blueprint.rb
+++ b/app/blueprints/talent_blueprint.rb
@@ -19,6 +19,10 @@ class TalentBlueprint < Blueprinter::Base
     association :tags, blueprint: TagBlueprint do |talent, options|
       options[:tags] || talent.user.tags
     end
+
+    field :followers_count do |talent, _options|
+      talent.user.following.count
+    end
     association :milestones, blueprint: MilestoneBlueprint, view: :normal
     association :career_goal, blueprint: CareerGoalBlueprint, view: :normal
   end

--- a/app/packs/src/components/talent/TalentShow.jsx
+++ b/app/packs/src/components/talent/TalentShow.jsx
@@ -45,6 +45,7 @@ const TalentShow = ({
   goals,
   posts,
   isFollowing,
+  followersCount,
   railsContext,
 }) => {
   const url = new URL(window.location);
@@ -69,6 +70,7 @@ const TalentShow = ({
     profilePictureUrl,
     tags,
     isFollowing,
+    followersCount,
     careerGoal,
     goals,
     posts,

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -41,6 +41,7 @@
           currentUserId: current_user&.id,
           tokenLive: @talent["token"]["deployed"],
           isFollowing: @talent["is_following"],
+          followersCount: @talent["followers_count"],
           admin: current_user ? current_user.admin? : false,
           user: {
             id: @talent["user_id"],


### PR DESCRIPTION
## Summary

This PR sends the count of followers to the ui. We will show this value next to the star icon.

## Notion link

<!--- Link to the Notion task. -->

## How to test?

<!--- instructions on how to test the changes. -->

## Notes

<!--- Notes you might consider worth adding. -->
