### PR TITLE
Hide hiden profiles from basic users

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -18,6 +18,10 @@ class UsersController < ApplicationController
   end
 
   def show
+    if @user.talent&.hide_profile && current_user.role != "admin" && current_user.id != @user.id
+      redirect_to root_url
+    end
+
     talent = @user.talent
     investor = @user.investor
 


### PR DESCRIPTION
## Summary

Hidden profiles were still accessible to basic users but we actually don't want to allow that.