### PR TITLE
Add last access at attribute to users.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -35,7 +35,7 @@ class ApplicationController < ActionController::Base
 
   def track_user_activity
     # safe navigation is required for non-auth users (sign_up, login)
-    current_user&.touch
+    current_user&.update_column(:last_access_at, Time.zone.now)
   end
 
   def id_param

--- a/db/migrate/20220712100355_add_last_access_at_to_users.rb
+++ b/db/migrate/20220712100355_add_last_access_at_to_users.rb
@@ -1,0 +1,5 @@
+class AddLastAccessAtToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :last_access_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_06_09_162621) do
-
+ActiveRecord::Schema.define(version: 2022_07_12_100355) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -402,8 +401,8 @@ ActiveRecord::Schema.define(version: 2022_06_09_162621) do
     t.boolean "welcome_pop_up", default: false
     t.boolean "tokens_purchased", default: false
     t.boolean "token_purchase_reminder_sent", default: false
-    t.string "theme_preference", default: "light"
     t.boolean "disabled", default: false
+    t.string "theme_preference", default: "light"
     t.boolean "messaging_disabled", default: false
     t.jsonb "notification_preferences", default: {}
     t.string "user_nft_address"
@@ -417,6 +416,7 @@ ActiveRecord::Schema.define(version: 2022_06_09_162621) do
     t.bigint "race_id"
     t.string "profile_type", default: "supporter", null: false
     t.boolean "first_quest_popup", default: false, null: false
+    t.datetime "last_access_at"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["invite_id"], name: "index_users_on_invite_id"
     t.index ["race_id"], name: "index_users_on_race_id"


### PR DESCRIPTION
## Summary

This PR adds a date attribute to the users table that will help tracking users activity in the platform.

## Notion link

<!--- Link to the Notion task. -->

## How to test?

<!--- instructions on how to test the changes. -->

## Notes

<!--- Notes you might consider worth adding. -->
