### PR TITLE
Fix: Load supporter count from db

### DIFF
--- a/app/blueprints/talent_blueprint.rb
+++ b/app/blueprints/talent_blueprint.rb
@@ -2,7 +2,7 @@ class TalentBlueprint < Blueprinter::Base
   fields :id, :profile_picture_url
 
   view :normal do
-    fields :occupation, :headline, :user_id
+    fields :occupation, :headline, :user_id, :supporters_count
     association :token, blueprint: TokenBlueprint, view: :normal
     association :user, blueprint: UserBlueprint, view: :normal
 
@@ -13,7 +13,7 @@ class TalentBlueprint < Blueprinter::Base
 
   view :extended do
     include_view :normal
-    fields :banner_url, :profile, :public
+    fields :banner_url, :profile, :public, :supporters_count
     association :user, blueprint: UserBlueprint, view: :extended
     association :perks, blueprint: PerkBlueprint
     association :tags, blueprint: TagBlueprint do |talent, options|

--- a/app/packs/src/components/discovery/discovery_rows.jsx
+++ b/app/packs/src/components/discovery/discovery_rows.jsx
@@ -161,7 +161,7 @@ const DiscoveryRows = ({ discoveryRows, updateFollow }) => {
                       updateFollow={() => updateFollow(talent)}
                       talentLink={`/u/${talent.username}`}
                       marketCap={talent.marketCap}
-                      supporterCount={talent.supporterCount}
+                      supporterCount={talent.supportersCount}
                     />
                   </div>
                 ))}

--- a/app/packs/src/components/discovery/index.jsx
+++ b/app/packs/src/components/discovery/index.jsx
@@ -45,12 +45,10 @@ const Discovery = ({ discoveryRows, marketingArticles, user }) => {
         const totalSupply = ethers.utils.formatUnits(
           talentFromChain.totalSupply || 0
         );
-        const supporterCount = talentFromChain.supporterCounter;
 
         return {
           ...talent,
           marketCap: parseAndCommify(totalSupply * 0.1),
-          supporterCount: supporterCount,
         };
       } else {
         return { ...talent };

--- a/app/packs/src/components/one_time_popups/FirstQuestPopup.jsx
+++ b/app/packs/src/components/one_time_popups/FirstQuestPopup.jsx
@@ -20,11 +20,17 @@ const FirstQuestPopup = ({ userId }) => {
     });
   };
 
+  const markAsRead = () => {
+    patch(`/api/v1/users/${userId}`, {
+      first_quest_popup: true,
+    }).then(() => setShow(false));
+  };
+
   return (
     <Modal
       scrollable={true}
       show={show}
-      onHide={() => setShow(false)}
+      onHide={markAsRead}
       centered
       dialogClassName={mobile ? "mw-100 mh-100 m-0" : "remove-background"}
       contentClassName={mobile ? "h-100" : ""}
@@ -48,7 +54,7 @@ const FirstQuestPopup = ({ userId }) => {
         <div className="d-flex mt-6 w-100">
           <Button
             className="mr-2 w-50"
-            onClick={() => setShow(false)}
+            onClick={markAsRead}
             text="Cancel"
             type="white-subtle"
             size="big"

--- a/app/packs/src/components/talent/Edit/About.jsx
+++ b/app/packs/src/components/talent/Edit/About.jsx
@@ -84,7 +84,7 @@ const About = (props) => {
     profile: false,
     public: false,
   });
-  const [opentoJobOffers, setOpentoJobOffers] = useState(
+  const [openToJobOffers, setOpenToJobOffers] = useState(
     props.talent.open_to_job_offers
   );
 
@@ -168,17 +168,16 @@ const About = (props) => {
     }
   };
 
-  const changeOpenToOffersAttribute = (attribute, value) => {
+  const changeOpenToOffersAttribute = (value) => {
     trackChanges(true);
-    validateWebsite(attribute, value);
 
-    setOpentoJobOffers(value);
+    setOpenToJobOffers(value);
 
     changeSharedState((prev) => ({
       ...prev,
       talent: {
-        open_to_job_offers: value,
         ...prev.talent,
+        open_to_job_offers: value,
       },
     }));
   };
@@ -386,8 +385,8 @@ const About = (props) => {
         </P2>
         <Checkbox
           className="form-check-input mt-4"
-          checked={opentoJobOffers}
-          onChange={() => changeOpenToOffersAttribute(!opentoJobOffers)}
+          checked={openToJobOffers}
+          onChange={() => changeOpenToOffersAttribute(!openToJobOffers)}
         >
           <div className="d-flex flex-wrap">
             <P2 className="mr-1" text="I'm open to new job offers" />

--- a/app/packs/src/components/talent/Edit/Profile.jsx
+++ b/app/packs/src/components/talent/Edit/Profile.jsx
@@ -208,32 +208,34 @@ const Profile = (props) => {
   return (
     <>
       <div className="edit-profile-fixed-bar">
-        <Tooltip
-          body={`You are missing the following fields: ${requiredFields.join(
-            ", "
-          )}`}
-          popOverAccessibilityId={"progressStats"}
-          mode={theme.mode()}
-          hide={requiredFields.length == 0}
-        >
-          <div
-            className={`edit-profile-talent-progress-container-${alertBarColor()} py-2 px-3`}
+        {progress != 100 && (
+          <Tooltip
+            body={`You are missing the following fields: ${requiredFields.join(
+              ", "
+            )}`}
+            popOverAccessibilityId={"progressStats"}
+            mode={theme.mode()}
+            hide={requiredFields.length == 0}
           >
-            <div className="d-flex flex-row w-100 justify-content-between edit-profile-talent-progress">
-              {/* below is required so the justify-content-between aligns properly */}
-              <P3 text="" />
-              <P3
-                mode={theme.mode()}
-                text={alertBarText()}
-                bold
-                className="current-color"
-              />
-              <P3 mode={theme.mode()} className="current-color">
-                <strong>{progress}</strong>/100%
-              </P3>
+            <div
+              className={`edit-profile-talent-progress-container-${alertBarColor()} py-2 px-3`}
+            >
+              <div className="d-flex flex-row w-100 justify-content-between edit-profile-talent-progress">
+                {/* below is required so the justify-content-between aligns properly */}
+                <P3 text="" />
+                <P3
+                  mode={theme.mode()}
+                  text={alertBarText()}
+                  bold
+                  className="current-color"
+                />
+                <P3 mode={theme.mode()} className="current-color">
+                  <strong>{progress}</strong>/100%
+                </P3>
+              </div>
             </div>
-          </div>
-        </Tooltip>
+          </Tooltip>
+        )}
         <div className="talent-table-tabs w-100 horizontal-scroll hide-scrollbar">
           <div
             className={cx(

--- a/app/packs/src/components/talent/Show/SimpleTokenDetails.jsx
+++ b/app/packs/src/components/talent/Show/SimpleTokenDetails.jsx
@@ -23,6 +23,7 @@ const SimpleTokenDetails = ({
   token,
   ticker,
   supportingCount,
+  supportersCount,
   mode,
   railsContext,
 }) => {
@@ -35,7 +36,6 @@ const SimpleTokenDetails = ({
   const [tokenData, setTokenData] = useState({
     price: 0.1,
     totalSupply: 0,
-    supporterCount: 0,
   });
 
   useEffect(() => {
@@ -50,7 +50,6 @@ const SimpleTokenDetails = ({
     setTokenData({
       ...tokenData,
       totalSupply: ethers.utils.formatUnits(data.talentToken.totalSupply || 0),
-      supporterCount: data.talentToken.supporterCounter || 0,
     });
   }, [data, loading]);
 
@@ -94,7 +93,7 @@ const SimpleTokenDetails = ({
           </div>
           <div className="card disabled d-flex flex-column align-items-center justify-content-center mb-4 p-3">
             <P2 className="mb-2 text-primary-04" bold text="Supporters" />
-            <H4 bold text={`${tokenData.supporterCount}`} />
+            <H4 bold text={`${supportersCount}`} />
           </div>
           {token?.contract_id && (
             <div className="card card-no-hover d-flex flex-column align-items-center justify-content-center p-3">

--- a/app/packs/src/components/talent/TalentPage.jsx
+++ b/app/packs/src/components/talent/TalentPage.jsx
@@ -9,7 +9,6 @@ import {
   client,
 } from "src/utils/thegraph";
 import {
-  getSupporterCount,
   getMarketCap,
   getProgress,
   getMarketCapVariance,
@@ -129,7 +128,6 @@ const TalentPage = ({ talents, isAdmin }) => {
         id,
         totalSupply,
         maxSupply,
-        supporterCounter,
         tokenDayData,
         createdAtTimestamp,
         ...rest
@@ -150,7 +148,6 @@ const TalentPage = ({ talents, isAdmin }) => {
           token: { contractId: id },
           progress: getProgress(totalSupply, maxSupply),
           marketCap: getMarketCap(totalSupply),
-          supporterCounter: getSupporterCount(supporterCounter),
           marketCapVariance: getMarketCapVariance(
             tokenDayData || [],
             deployDateUTC || 0,
@@ -164,23 +161,12 @@ const TalentPage = ({ talents, isAdmin }) => {
     setLocalTalents((prev) =>
       Object.values(
         [...prev, ...newTalents].reduce(
-          (
-            result,
-            {
-              id,
-              token,
-              marketCap,
-              supporterCounter,
-              marketCapVariance,
-              ...rest
-            }
-          ) => {
+          (result, { id, token, marketCap, marketCapVariance, ...rest }) => {
             result[token.contractId || id] = {
               ...(result[token.contractId || id] || {}),
               id: result[token.contractId || id]?.id || id,
               token: { ...result[token.contractId]?.token, ...token },
               marketCap: marketCap || "-1",
-              supporterCounter: supporterCounter || "-1",
               marketCapVariance: marketCapVariance || 0,
               ...rest,
             };

--- a/app/packs/src/components/talent/TalentShow.jsx
+++ b/app/packs/src/components/talent/TalentShow.jsx
@@ -46,6 +46,7 @@ const TalentShow = ({
   posts,
   isFollowing,
   followersCount,
+  supportersCount,
   railsContext,
 }) => {
   const url = new URL(window.location);
@@ -539,6 +540,7 @@ const TalentShow = ({
               ticker={ticker()}
               token={token}
               mode={theme.mode()}
+              supportersCount={supportersCount}
               railsContext={railsContext}
             />
           </div>

--- a/app/packs/src/components/talent/TalentTableCardMode.jsx
+++ b/app/packs/src/components/talent/TalentTableCardMode.jsx
@@ -31,7 +31,7 @@ const TalentTableCardMode = ({
             updateFollow={() => updateFollow(talent)}
             talentLink={`/u/${talent.user.username}`}
             marketCap={talent.marketCap}
-            supporterCount={talent.supporterCounter}
+            supporterCount={talent.supportersCount}
             publicPageViewer={publicPageViewer}
           />
         </div>

--- a/app/packs/src/components/talent/TalentTableListMode.jsx
+++ b/app/packs/src/components/talent/TalentTableListMode.jsx
@@ -163,7 +163,7 @@ const TalentTableListMode = ({
     const contractId = talent.token.contractId;
     switch (selectedSort) {
       case "Supporters":
-        return contractId ? talent.supporterCounter : "-";
+        return contractId ? talent.supportersCount : "-";
       case "Occupation":
         return talent.occupation;
       case "Market Cap":
@@ -368,7 +368,7 @@ const TalentTableListMode = ({
               <P2
                 text={
                   talent.token.contractId
-                    ? `${talent.supporterCounter || 0}`
+                    ? `${talent.supportersCount || 0}`
                     : "-"
                 }
               />

--- a/app/packs/src/components/talent/utils/talent.js
+++ b/app/packs/src/components/talent/utils/talent.js
@@ -73,7 +73,7 @@ export const compareOccupation = (talent1, talent2) =>
   compareStrings(talent1.occupation, talent2.occupation);
 
 export const compareSupporters = (talent1, talent2) =>
-  compareNumbers(talent1.supporterCounter, talent2.supporterCounter);
+  compareNumbers(talent1.supportersCount, talent2.supportersCount);
 
 export const compareMarketCap = (talent1, talent2) => {
   const talent1Amount = ethers.utils.parseUnits(

--- a/app/packs/src/utils/thegraph.js
+++ b/app/packs/src/utils/thegraph.js
@@ -30,7 +30,6 @@ const GET_TALENT_PORTFOLIO = gql`
   query GetTalentList($ids: [String!], $startDate: Int!) {
     talentTokens(first: 500, where: { id_in: $ids }) {
       id
-      supporterCounter
       totalSupply
       maxSupply
       marketCap

--- a/app/services/api/update_talent.rb
+++ b/app/services/api/update_talent.rb
@@ -41,9 +41,9 @@ class API::UpdateTalent
         who_dunnit_id: user.id,
         new_profile_type: params[:profile_type]
       )
-    else
-      @talent.user.update!(params)
     end
+
+    @talent.user.update!(params.except(:profile_type))
   end
 
   def update_talent(params)

--- a/app/views/discovery/index.html.erb
+++ b/app/views/discovery/index.html.erb
@@ -18,6 +18,7 @@
             name: talent["user"]["name"],
             username: talent["user"]["username"],
             userId: talent["user_id"],
+            supportersCount: talent["supporters_count"],
           }}
         }},
         marketingArticles: @marketing_articles.map { |article| {

--- a/app/views/talent/index.html.erb
+++ b/app/views/talent/index.html.erb
@@ -9,6 +9,7 @@
               profilePictureUrl: talent["profile_picture_url"],
               occupation: talent["occupation"],
               headline: talent["headline"],
+              supportersCount: talent["supporters_count"],
               token: {
                 ticker: talent["token"]["ticker"],
                 contractId: talent["token"]["contract_id"],

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -42,6 +42,7 @@
           tokenLive: @talent["token"]["deployed"],
           isFollowing: @talent["is_following"],
           followersCount: @talent["followers_count"],
+          supportersCount: @talent["supporters_count"],
           admin: current_user ? current_user.admin? : false,
           user: {
             id: @talent["user_id"],

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,6 +11,7 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 2022_07_12_100355) do
+
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 


### PR DESCRIPTION
## Summary

After the smart contract migration the supporterCount field on thegraph is no longer up to date. We need to use the value from our database that we have from our TalentSupporter sync job.