### PR TITLE
Setup sidekiq concurrency and change job queue

### DIFF
--- a/.env
+++ b/.env
@@ -42,3 +42,4 @@ MINIO_ENDPOINT=minio_endpoint
 DISCORD_WEBHOOK_URL=discord_webhook_url
 EMAIL_REGEX_WITHOUT_ALIASES=email_regex_without_aliases
 DISABLE_SMART_CONTRACTS=disable_smart_contracts
+SIDEKIQ_CONCURRENCY=sidekiq_concurrency

--- a/app/jobs/create_profile_page_visitor_job.rb
+++ b/app/jobs/create_profile_page_visitor_job.rb
@@ -1,5 +1,5 @@
 class CreateProfilePageVisitorJob < ApplicationJob
-  queue_as :default
+  queue_as :low
 
   def perform(ip:, user_id:)
     user = User.find(user_id)

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,3 +1,4 @@
+:concurrency: <%= ENV["SIDEKIQ_CONCURRENCY"] || 10 %>
 :logfile: log/sidekiq.log
 :queues:
   - critical
@@ -5,6 +6,8 @@
   - default
   - mailers
   - low
+:limits:
+  low: 1
 :schedule:
   send_notification_digests:
     cron: "0 10 * * *" # runs once every day at 10am


### PR DESCRIPTION
## Summary

This PR adds an environment variable that sets the sidekiq concurrency and changes the profile page visitor queue to low

## Notion link

<!--- Link to the Notion task. -->

## How to test?

<!--- instructions on how to test the changes. -->

## Notes

<!--- Notes you might consider worth adding. -->
