### PR TITLE
Add last_investment at to talent supporters

### DIFF
--- a/app/services/talents/refresh_supporters.rb
+++ b/app/services/talents/refresh_supporters.rb
@@ -57,6 +57,7 @@ module Talents
         talent_supporter.update!(
           amount: supporter.amount,
           tal_amount: supporter.tal_amount,
+          last_time_bought_at: Time.at(supporter.last_time_bought_at.to_i),
           synced_at: Time.zone.now
         )
       end

--- a/db/migrate/20220713152311_add_last_time_bought_at_to_talent_supporters.rb
+++ b/db/migrate/20220713152311_add_last_time_bought_at_to_talent_supporters.rb
@@ -1,0 +1,5 @@
+class AddLastTimeBoughtAtToTalentSupporters < ActiveRecord::Migration[6.1]
+  def change
+    add_column :talent_supporters, :last_time_bought_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_07_12_134121) do
+ActiveRecord::Schema.define(version: 2022_07_13_152311) do
+
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -139,16 +140,6 @@ ActiveRecord::Schema.define(version: 2022_07_12_134121) do
     t.bigint "career_goal_id"
     t.string "title"
     t.index ["career_goal_id"], name: "index_goals_on_career_goal_id"
-  end
-
-  create_table "impersonations", force: :cascade do |t|
-    t.integer "impersonator_id", null: false
-    t.integer "impersonated_id", null: false
-    t.text "ip_ciphertext", null: false
-    t.string "ip_bidx"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["ip_bidx"], name: "index_impersonations_on_ip_bidx"
   end
 
   create_table "investors", force: :cascade do |t|
@@ -333,6 +324,7 @@ ActiveRecord::Schema.define(version: 2022_07_12_134121) do
     t.datetime "synced_at", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.datetime "last_time_bought_at"
     t.index ["supporter_wallet_id", "talent_contract_id"], name: "talent_supporters_wallet_token_contract_uidx", unique: true
   end
 
@@ -411,8 +403,8 @@ ActiveRecord::Schema.define(version: 2022_07_12_134121) do
     t.boolean "welcome_pop_up", default: false
     t.boolean "tokens_purchased", default: false
     t.boolean "token_purchase_reminder_sent", default: false
-    t.boolean "disabled", default: false
     t.string "theme_preference", default: "light"
+    t.boolean "disabled", default: false
     t.boolean "messaging_disabled", default: false
     t.jsonb "notification_preferences", default: {}
     t.string "user_nft_address"
@@ -436,17 +428,6 @@ ActiveRecord::Schema.define(version: 2022_07_12_134121) do
     t.index ["wallet_id"], name: "index_users_on_wallet_id", unique: true
   end
 
-  create_table "versions", force: :cascade do |t|
-    t.string "item_type", null: false
-    t.bigint "item_id", null: false
-    t.string "event", null: false
-    t.string "whodunnit"
-    t.text "object"
-    t.datetime "created_at"
-    t.text "object_changes"
-    t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
-  end
-
   create_table "wait_list", force: :cascade do |t|
     t.boolean "approved", default: false
     t.string "email", null: false
@@ -467,8 +448,6 @@ ActiveRecord::Schema.define(version: 2022_07_12_134121) do
   add_foreign_key "follows", "users"
   add_foreign_key "follows", "users", column: "follower_id"
   add_foreign_key "goals", "career_goals"
-  add_foreign_key "impersonations", "users", column: "impersonated_id"
-  add_foreign_key "impersonations", "users", column: "impersonator_id"
   add_foreign_key "invites", "users"
   add_foreign_key "marketing_articles", "users"
   add_foreign_key "milestones", "talent"

--- a/spec/services/talents/refresh_supporters_spec.rb
+++ b/spec/services/talents/refresh_supporters_spec.rb
@@ -76,19 +76,35 @@ RSpec.describe Talents::RefreshSupporters do
           id: SecureRandom.hex,
           supporter: OpenStruct.new(id: "99asn"),
           amount: "60000000000000000000",
-          tal_amount: "300000000000000000000"
+          tal_amount: "300000000000000000000",
+          last_time_bought_at: "1657727823"
         ),
         OpenStruct.new(
           id: SecureRandom.hex,
           supporter: OpenStruct.new(id: "01ksh"),
           amount: "90000000000000000000",
-          tal_amount: "450000000000000000000"
+          tal_amount: "450000000000000000000",
+          last_time_bought_at: "1657564775"
         )
       ]
     end
 
-    let!(:talent_supporter_one) { create :talent_supporter, supporter_wallet_id: "99asn", talent_contract_id: talent_contract_id }
-    let!(:talent_supporter_two) { create :talent_supporter, supporter_wallet_id: "01ksh", talent_contract_id: talent_contract_id }
+    let!(:talent_supporter_one) do
+      create(
+        :talent_supporter,
+        supporter_wallet_id: "99asn",
+        talent_contract_id: talent_contract_id,
+        tal_amount: "300000000000000000000"
+      )
+    end
+    let!(:talent_supporter_two) do
+      create(
+        :talent_supporter,
+        supporter_wallet_id: "01ksh",
+        talent_contract_id: talent_contract_id,
+        tal_amount: "200"
+      )
+    end
 
     it "does not create extra talent supporter records" do
       expect { refresh_supporters }.not_to change(TalentSupporter, :count)
@@ -103,9 +119,11 @@ RSpec.describe Talents::RefreshSupporters do
       aggregate_failures do
         expect(talent_supporter_one.amount).to eq "60000000000000000000"
         expect(talent_supporter_one.tal_amount).to eq "300000000000000000000"
+        expect(talent_supporter_one.last_time_bought_at).to eq Time.at(1657727823)
 
         expect(talent_supporter_two.amount).to eq "90000000000000000000"
         expect(talent_supporter_two.tal_amount).to eq "450000000000000000000"
+        expect(talent_supporter_two.last_time_bought_at).to eq Time.at(1657564775)
       end
     end
   end


### PR DESCRIPTION
## Summary

This PR adds a date with the last time a supporter bought the token.

## Notion link

<!--- Link to the Notion task. -->

## How to test?

<!--- instructions on how to test the changes. -->

## Notes

<!--- Notes you might consider worth adding. -->
