### PR TITLE
Add sender to new message notification params

### DIFF
--- a/app/services/create_notification.rb
+++ b/app/services/create_notification.rb
@@ -8,6 +8,7 @@ class CreateNotification
     )
 
     if notification.present? && notification.unread_for_more_than_a_week?
+      notification.update!(params: notification_params(source_id, model_id, extra_params))
       send(notification.to_notification, recipient)
 
       notification.mark_as_read!

--- a/spec/integration/notifications/message_notifications_delivery_spec.rb
+++ b/spec/integration/notifications/message_notifications_delivery_spec.rb
@@ -53,6 +53,16 @@ RSpec.describe "Message notifications delivery" do
       expect { send_message }.to change(Notification, :count).from(1).to(2)
     end
 
+    it "creates the new notification with the correct params" do
+      send_message
+
+      new_notification = Notification.last
+
+      expect(new_notification.params).to eq({
+        "sender_id" => sender.id
+      })
+    end
+
     it "marks the old notification as read" do
       send_message
 


### PR DESCRIPTION
## Summary

This PR adds the last sender to notifications unread for more than a week

## Notion link

<!--- Link to the Notion task. -->

## How to test?

<!--- instructions on how to test the changes. -->

## Notes

<!--- Notes you might consider worth adding. -->
