### PR TITLE
Move reminder timestamps updates to mailers

### DIFF
--- a/app/jobs/email_reminders/send_complete_profile_reminder_job.rb
+++ b/app/jobs/email_reminders/send_complete_profile_reminder_job.rb
@@ -9,9 +9,8 @@ module EmailReminders
         .where("talent.created_at < ?", ENV["EMAIL_REMINDER_DAYS"].to_i.days.ago)
         .where("quests.type = ? AND status != ?", "Quests::TalentProfile", "done")
 
-      users.each do |user|
+      users.find_each do |user|
         UserMailer.with(user: user).send_complete_profile_reminder_email.deliver_later
-        user.update!(complete_profile_reminder_sent_at: Time.zone.now)
       end
     end
   end

--- a/app/jobs/email_reminders/send_digest_email_job.rb
+++ b/app/jobs/email_reminders/send_digest_email_job.rb
@@ -10,9 +10,8 @@ module EmailReminders
         users = users.where(role: "admin")
       end
 
-      users.each do |user|
+      users.find_each do |user|
         UserMailer.with(user: user).send_digest_email.deliver_later
-        user.update!(digest_email_sent_at: Time.zone.now)
       end
     end
   end

--- a/app/jobs/email_reminders/send_token_launch_reminder_job.rb
+++ b/app/jobs/email_reminders/send_token_launch_reminder_job.rb
@@ -9,9 +9,8 @@ module EmailReminders
         .where(token: {deployed: false})
         .where("talent.created_at < ?", ENV["EMAIL_REMINDER_DAYS"].to_i.days.ago)
 
-      users.each do |user|
+      users.find_each do |user|
         UserMailer.with(user: user).send_token_launch_reminder_email.deliver_later
-        user.update!(token_launch_reminder_sent_at: Time.now)
       end
     end
   end

--- a/app/jobs/email_reminders/send_token_purchase_reminder_job.rb
+++ b/app/jobs/email_reminders/send_token_purchase_reminder_job.rb
@@ -10,9 +10,8 @@ module EmailReminders
         .where(token_purchase_reminder_sent_at: nil)
         .where("investors.created_at < ?", ENV["EMAIL_REMINDER_DAYS"].to_i.days.ago)
 
-      users.each do |user|
+      users.find_each do |user|
         UserMailer.with(user: user).send_token_purchase_reminder_email.deliver_later
-        user.update!(token_purchase_reminder_sent_at: Time.now)
       end
     end
   end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -24,6 +24,8 @@ class UserMailer < ApplicationMailer
 
   def send_token_launch_reminder_email
     @user = indifferent_access_params[:user]
+    @user.update!(token_launch_reminder_sent_at: Time.now)
+
     bootstrap_mail(to: @user.email, subject: "All set - It's time to launch your token!")
   end
 
@@ -34,6 +36,8 @@ class UserMailer < ApplicationMailer
 
   def send_token_purchase_reminder_email
     @user = indifferent_access_params[:user]
+    @user.update!(token_purchase_reminder_sent_at: Time.now)
+
     bootstrap_mail(to: @user.email, subject: "You're missing out on $TAL rewards!")
   end
 
@@ -56,6 +60,7 @@ class UserMailer < ApplicationMailer
 
   def send_complete_profile_reminder_email
     @user = indifferent_access_params[:user]
+    @user.update!(complete_profile_reminder_sent_at: Time.zone.now)
     bootstrap_mail(to: @user.email, subject: "Complete your profile and launch your token today 🚀")
   end
 
@@ -76,14 +81,16 @@ class UserMailer < ApplicationMailer
     @invested_in_talents = Talent.where(user: invested_in_users).includes(:user)
     set_talent_profile_pictures_attachments(@invested_in_talents)
 
-    @talents = Talent.base.active.where("tokens.deployed_at > ?", digest_email_sent_at).includes(:user).limit(3)
+    @talents = Talent.base.active.where("tokens.deployed_at > ?", 2.weeks.ago).includes(:user).limit(3)
 
     set_talent_profile_pictures_attachments(@talents)
 
     user_talent_supporters = TalentSupporter.where(supporter_wallet_id: @user.wallet_id)
 
     @tal_amount = user_talent_supporters.map { |t| t.tal_amount.to_i }.sum / Token::TAL_DECIMALS
-    @usd_amount = @tal_amount * Token::TAL_VALUE_IN_USD
+    @usd_amount = (@tal_amount * Token::TAL_VALUE_IN_USD).round
+
+    @user.update!(digest_email_sent_at: Time.zone.now)
 
     bootstrap_mail(to: @user.email, subject: "The latest on Talent Protocol")
   end

--- a/app/views/user_mailer/send_digest_email.html.erb
+++ b/app/views/user_mailer/send_digest_email.html.erb
@@ -46,7 +46,7 @@
     Your rewards in Talent Protocol
   </p>
   <p class="w-full lh-lg text-lg mb-10 primary-3 paragraph">
-    You have accumulated <%= @tal_amount %> $TAL worth <%= @usd_amount %> $USD since you've joined. 
+    You have accumulated <%= @tal_amount %> $TAL worth <%= @usd_amount %> $USD since you've joined by supporting others.
   </p>
   <%= link_to "Check my reward balance", portfolio_url, class: "btn btn-primary fw-800 text-5xl py-4 mb-5 w-full" %>
 </div>

--- a/spec/jobs/email_reminders/send_complete_profile_reminder_job_spec.rb
+++ b/spec/jobs/email_reminders/send_complete_profile_reminder_job_spec.rb
@@ -41,10 +41,14 @@ RSpec.describe EmailReminders::SendCompleteProfileReminderJob, type: :job do
   end
 
   it "sets the timestamp when the complete profile reminder was sent to the user" do
-    freeze_time do
-      send_complete_profile_reminder_email
+    Sidekiq::Testing.inline! do
+      freeze_time do
+        send_complete_profile_reminder_email
 
-      expect(user_1.reload.complete_profile_reminder_sent_at).to eq(Time.zone.now)
+        perform_enqueued_jobs
+
+        expect(user_1.reload.complete_profile_reminder_sent_at).to eq(Time.zone.now)
+      end
     end
   end
 end

--- a/spec/jobs/email_reminders/send_digest_email_job_spec.rb
+++ b/spec/jobs/email_reminders/send_digest_email_job_spec.rb
@@ -44,12 +44,16 @@ RSpec.describe EmailReminders::SendDigestEmailJob, type: :job do
     end
 
     it "sets the timestamp when the complete profile reminder was sent to the user" do
-      freeze_time do
-        send_digest_email
+      Sidekiq::Testing.inline! do
+        freeze_time do
+          send_digest_email
 
-        expect(user_1.reload.digest_email_sent_at).to eq(Time.zone.now)
-        expect(user_2.reload.digest_email_sent_at).to eq(Time.zone.now)
-        expect(user_5.reload.digest_email_sent_at).to eq(Time.zone.now)
+          perform_enqueued_jobs
+
+          expect(user_1.reload.digest_email_sent_at).to eq(Time.zone.now)
+          expect(user_2.reload.digest_email_sent_at).to eq(Time.zone.now)
+          expect(user_5.reload.digest_email_sent_at).to eq(Time.zone.now)
+        end
       end
     end
   end
@@ -75,10 +79,14 @@ RSpec.describe EmailReminders::SendDigestEmailJob, type: :job do
     end
 
     it "sets the timestamp when the complete profile reminder was sent to the user" do
-      freeze_time do
-        send_digest_email
+      Sidekiq::Testing.inline! do
+        freeze_time do
+          send_digest_email
 
-        expect(user_1.reload.digest_email_sent_at).to eq(Time.zone.now)
+          perform_enqueued_jobs
+
+          expect(user_1.reload.digest_email_sent_at).to eq(Time.zone.now)
+        end
       end
     end
   end


### PR DESCRIPTION
## Summary

This PR fixes the way we are updating email reminder timestamps. Since we run the digest mailer in a job and the mailer uses the value to compute data we can only update it after fetching the data.

## Notion link

https://www.notion.so/talentprotocol/Platform-Emails-9bd47f988fb947d7aa0e775dfa036499

## How to test?

<!--- instructions on how to test the changes. -->

## Notes

<!--- Notes you might consider worth adding. -->
