### PR TITLE
Add daily metrics table.

### DIFF
--- a/app/jobs/daily_metrics_job.rb
+++ b/app/jobs/daily_metrics_job.rb
@@ -1,0 +1,195 @@
+class DailyMetricsJob < ApplicationJob
+  queue_as :low
+
+  def perform
+    DailyMetric.create!(
+      date: date,
+      total_users: total_users,
+      total_connected_wallets: total_connected_wallets,
+      total_active_users: total_active_users,
+      total_dead_accounts: total_dead_accounts,
+      total_talent_profiles: total_talent_profiles,
+      talent_applications: talent_applications,
+      total_advocates: total_advocates,
+      total_scouts: total_scouts,
+      total_beginner_quests_completed: total_beginner_quests_completed,
+      total_complete_profile_quests_completed: total_complete_profile_quests_completed,
+      total_ambassador_quests_completed: total_ambassador_quests_completed,
+      total_supporter_quests_completed: total_supporter_quests_completed,
+      total_celo_tokens: total_celo_tokens,
+      total_celo_supporters: total_celo_supporters,
+      total_polygon_tokens: total_polygon_tokens,
+      total_polygon_supporters: total_polygon_supporters,
+      total_engaged_users: total_engaged_users
+    )
+  end
+
+  private
+
+  def date
+    Date.yesterday
+  end
+
+  def total_users
+    User.count
+  end
+
+  def total_connected_wallets
+    User.where.not(wallet_id: nil).count
+  end
+
+  def total_active_users
+    User.where("users.last_access_at > ?", one_month_ago).count
+  end
+
+  def total_dead_accounts
+    query = <<~SQL
+      SELECT COUNT(*)
+      FROM users
+      WHERE (
+          users.last_access_at > (current_date - interval '60' day)
+          AND DATE(users.created_at) = DATE(users.last_access_at)
+      ) OR users.last_access_at < (current_date - interval '180' day)
+    SQL
+
+    sanitized_sql = ActiveRecord::Base.sanitize_sql_array([query])
+
+    ActiveRecord::Base.connection.execute(sanitized_sql).first["count"]
+  end
+
+  def total_talent_profiles
+    Talent.count
+  end
+
+  def total_engaged_users
+    query = <<~SQL
+      SELECT COUNT(*)
+      FROM users
+      WHERE users.id IN (
+          select talent.user_id
+          from talent
+          left join tokens on talent.id = tokens.talent_id
+          left join career_goals on talent.id = career_goals.talent_id
+          left join perks on talent.id = perks.talent_id
+          left join milestones on talent.id = milestones.talent_id
+          left join goals on career_goals.id = goals.career_goal_id
+          where talent.updated_at > :one_month_ago
+          OR tokens.updated_at > :one_month_ago
+          OR career_goals.updated_at > :one_month_ago
+          OR perks.updated_at > :one_month_ago
+          OR perks.created_at > :one_month_ago
+          OR milestones.updated_at > :one_month_ago
+          OR milestones.created_at > :one_month_ago
+          OR goals.updated_at > :one_month_ago
+          OR goals.created_at > :one_month_ago
+      )
+      OR users.id IN (
+          select investors.user_id
+          from investors
+          where investors.updated_at > :one_month_ago
+      )
+      OR users.wallet_id IN (
+          select talent_supporters.supporter_wallet_id
+          from talent_supporters
+          where talent_supporters.last_time_bought_at > :one_month_ago
+      )
+      OR users.id IN (
+          select messages.sender_id
+          from messages
+          where messages.created_at > :one_month_ago
+      )
+      OR users.id IN (
+          select follows.follower_id
+          from follows
+          where follows.created_at > :one_month_ago
+      )
+    SQL
+
+    sanitized_sql = ActiveRecord::Base.sanitize_sql_array([query, one_month_ago: one_month_ago])
+
+    ActiveRecord::Base.connection.execute(sanitized_sql).first["count"]
+  end
+
+  def talent_applications
+    query = <<~SQL
+      SELECT COUNT(DISTINCT(user_id))
+      FROM user_profile_type_changes
+      where new_profile_type = 'waiting_for_approval'
+      AND created_at::date = :date
+    SQL
+
+    sanitized_sql = ActiveRecord::Base.sanitize_sql_array([query, date: date])
+
+    ActiveRecord::Base.connection.execute(sanitized_sql).first["count"]
+  end
+
+  def total_advocates
+    query = <<~SQL
+      SELECT COUNT(DISTINCT user_id)
+      FROM invites
+      where id IN (
+          SELECT invite_id
+          FROM users
+          WHERE tokens_purchased = true
+      )
+    SQL
+
+    sanitized_sql = ActiveRecord::Base.sanitize_sql_array([query, date: date])
+
+    ActiveRecord::Base.connection.execute(sanitized_sql).first["count"]
+  end
+
+  def total_scouts
+    query = <<~SQL
+      SELECT COUNT(DISTINCT user_id)
+      FROM invites
+      where id IN (
+          SELECT invite_id
+          FROM users
+          INNER JOIN talent on users.id = talent.user_id
+          INNER JOIN tokens on talent.id = tokens.talent_id
+          WHERE tokens.contract_id IS NOT NULL
+      )
+    SQL
+
+    sanitized_sql = ActiveRecord::Base.sanitize_sql_array([query, date: date])
+
+    ActiveRecord::Base.connection.execute(sanitized_sql).first["count"]
+  end
+
+  def total_beginner_quests_completed
+    Quest.where(type: "Quests::User", status: "done").count
+  end
+
+  def total_complete_profile_quests_completed
+    Quest.where(type: "Quests::TalentProfile", status: "done").count
+  end
+
+  def total_ambassador_quests_completed
+    Quest.where(type: "Quests::Ambassador", status: "done").count
+  end
+
+  def total_supporter_quests_completed
+    Quest.where(type: "Quests::Supporter", status: "done").count
+  end
+
+  def total_celo_tokens
+    Token.where(deployed: true).count
+  end
+
+  def total_celo_supporters
+    User.where(tokens_purchased: true).count
+  end
+
+  def total_polygon_tokens
+    0
+  end
+
+  def total_polygon_supporters
+    0
+  end
+
+  def one_month_ago
+    @one_month_ago ||= 31.days.ago.beginning_of_day
+  end
+end

--- a/app/models/daily_metric.rb
+++ b/app/models/daily_metric.rb
@@ -1,0 +1,2 @@
+class DailyMetric < ApplicationRecord
+end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -35,3 +35,6 @@
     cron: "0 8 * * *" # runs once every day at 8am
     class: EmailReminders::SendDigestEmailJob
     enabled: <%= ENV["DIGEST_EMAIL_DAYS"].to_i > 0 %>
+  daily_metrics:
+    cron: "1 0 * * *" # runs once every day at 8am
+    class: DailyMetricsJob

--- a/db/migrate/20220721163639_create_daily_metrics.rb
+++ b/db/migrate/20220721163639_create_daily_metrics.rb
@@ -1,0 +1,34 @@
+class CreateDailyMetrics < ActiveRecord::Migration[6.1]
+  def change
+    create_table :daily_metrics do |t|
+      t.date :date, null: false, unique: true
+
+      t.integer :total_users
+      t.integer :total_connected_wallets
+      t.integer :total_active_users
+      t.integer :total_dead_accounts
+      t.integer :total_talent_profiles
+      t.integer :total_engaged_users
+
+      t.integer :total_advocates
+      t.integer :total_scouts
+
+      # daily metric
+      t.integer :talent_applications
+
+      # quests
+      t.integer :total_beginner_quests_completed
+      t.integer :total_complete_profile_quests_completed
+      t.integer :total_ambassador_quests_completed
+      t.integer :total_supporter_quests_completed
+
+      # tokens
+      t.integer :total_celo_tokens
+      t.integer :total_celo_supporters
+      t.integer :total_polygon_tokens
+      t.integer :total_polygon_supporters
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_07_13_152311) do
+ActiveRecord::Schema.define(version: 2022_07_21_163639) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -91,6 +91,29 @@ ActiveRecord::Schema.define(version: 2022_07_13_152311) do
     t.bigint "post_id"
     t.index ["post_id"], name: "index_comments_on_post_id"
     t.index ["user_id"], name: "index_comments_on_user_id"
+  end
+
+  create_table "daily_metrics", force: :cascade do |t|
+    t.date "date", null: false
+    t.integer "total_users"
+    t.integer "total_connected_wallets"
+    t.integer "total_active_users"
+    t.integer "total_dead_accounts"
+    t.integer "total_talent_profiles"
+    t.integer "total_engaged_users"
+    t.integer "total_advocates"
+    t.integer "total_scouts"
+    t.integer "talent_applications"
+    t.integer "total_beginner_quests_completed"
+    t.integer "total_complete_profile_quests_completed"
+    t.integer "total_ambassador_quests_completed"
+    t.integer "total_supporter_quests_completed"
+    t.integer "total_celo_tokens"
+    t.integer "total_celo_supporters"
+    t.integer "total_polygon_tokens"
+    t.integer "total_polygon_supporters"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "discovery_rows", force: :cascade do |t|
@@ -420,10 +443,10 @@ ActiveRecord::Schema.define(version: 2022_07_13_152311) do
     t.string "profile_type", default: "supporter", null: false
     t.boolean "first_quest_popup", default: false, null: false
     t.datetime "last_access_at"
-    t.datetime "token_launch_reminder_sent_at"
-    t.datetime "token_purchase_reminder_sent_at"
     t.datetime "complete_profile_reminder_sent_at"
     t.datetime "digest_email_sent_at"
+    t.datetime "token_launch_reminder_sent_at"
+    t.datetime "token_purchase_reminder_sent_at"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["invite_id"], name: "index_users_on_invite_id"
     t.index ["race_id"], name: "index_users_on_race_id"

--- a/spec/factories/follows.rb
+++ b/spec/factories/follows.rb
@@ -1,0 +1,4 @@
+FactoryBot.define do
+  factory :follow do
+  end
+end

--- a/spec/jobs/daily_metrics_job_spec.rb
+++ b/spec/jobs/daily_metrics_job_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+RSpec.describe DailyMetricsJob, type: :job do
+  let!(:user_1) { create :user, last_access_at: 5.days.ago }
+  let!(:talent) { create :talent, user: user_1, updated_at: Date.today }
+  let!(:token) { create :token, talent: talent, deployed: true }
+  let!(:user_2) { create :user, last_access_at: Date.yesterday, investor: investor }
+  let!(:investor) { create :investor, updated_at: Date.yesterday }
+
+  let!(:user_3) { create :user }
+  let!(:message) { create :message, sender: user_3, receiver: user_1, created_at: 10.days.ago }
+
+  let!(:user_4) { create :user }
+  let!(:follow) { create :follow, follower: user_4, user: user_1, created_at: 26.days.ago }
+
+  let!(:user_5) { create :user }
+  let!(:talent_supporter) { create :talent_supporter, supporter_wallet_id: user_5.wallet_id, talent_contract_id: token.contract_id, last_time_bought_at: 15.days.ago }
+
+  let!(:user_6) { create :user }
+
+  subject(:daily_metrics_refresh) { described_class.perform_now }
+
+  it "creates a new daily record" do
+    expect { daily_metrics_refresh }.to change(DailyMetric, :count).from(0).to(1)
+  end
+
+  it "creates a new daily record with the correct arguments" do
+    daily_metrics_refresh
+
+    created_daily_metric = DailyMetric.last
+
+    aggregate_failures do
+      expect(created_daily_metric.total_users).to eq 6
+      expect(created_daily_metric.date).to eq Date.yesterday
+      expect(created_daily_metric.total_talent_profiles).to eq 1
+      expect(created_daily_metric.total_engaged_users).to eq 5
+    end
+  end
+end


### PR DESCRIPTION
## Summary

The purpose of this table is to store our daily metrics so we can easily check how the product is doing daily.

## Notion link

https://www.notion.so/talentprotocol/Add-database-table-with-daily-metrics-2761eacd538549e885356adb24e5f94b

## How to test?

<!--- instructions on how to test the changes. -->

## Notes

<!--- Notes you might consider worth adding. -->
