### PR TITLE
Updated and tested Dockerfile and docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,8 +4,22 @@ services:
     image: postgres
     volumes:
       - ./tmp/db:/var/lib/postgresql/data
+    ports:
+      - '5432:5432'
     environment:
       POSTGRES_PASSWORD: password
+  redis:
+    image: redis
+    ports:
+      - '6379:6379'
+    volumes:
+      - ./tmp/redis:/data
+  minio:
+    image: minio/minio
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    command: minio server /data --console-address :9001
   web:
     build:
       context: .
@@ -15,7 +29,6 @@ services:
       - /mvp/node_modules
     ports:
       - "3000:3000"
-      - "3035:3035"
     environment:
       WEBPACKER_DEV_SERVER_HOST: 0.0.0.0
       DATABASE_HOST: "db"
@@ -23,3 +36,5 @@ services:
       DATABASE_PASSWORD: "password"
     depends_on:
       - db
+      - redis
+      - minio


### PR DESCRIPTION
## Summary

Updated the Dockerfile and the docker-compose.yml files in order to enable developers to run the dev environment without installing all the dependencies on their machines.

## Notion link

N/A

## How to test?
 
You can run the following command:
`docker-compose up` (you can add the -d flag if you don't want to see the outputs)

## Notes

You need a custom .env.development file for docker, you can ask @verdefred for it.
The following ports are exposed in your system for the different containers:
- 5432: Postgres
- 6379: Redis
- 9000: Minio cmd
- 9001: Minio webapp
- 3000: Talent Protocol webapp