### PR TITLE
Remove coming soon tag from waiting approval profile

### DIFF
--- a/app/blueprints/user_blueprint.rb
+++ b/app/blueprints/user_blueprint.rb
@@ -2,7 +2,7 @@ class UserBlueprint < Blueprinter::Base
   fields :id
 
   view :normal do
-    fields :username, :display_name
+    fields :username, :display_name, :profile_type
     field :name do |user, _options|
       user.display_name || user.username
     end

--- a/app/packs/src/components/design_system/cards/NewTalentCard.jsx
+++ b/app/packs/src/components/design_system/cards/NewTalentCard.jsx
@@ -27,6 +27,7 @@ const NewTalentCard = ({
   supporterCount,
   publicPageViewer,
   isVerified,
+  profileType,
 }) => {
   const { mobile } = useWindowDimensionsHook();
   const [showUserDetails, setShowUserDetails] = useState(false);
@@ -89,7 +90,15 @@ const NewTalentCard = ({
               <P2 className="text-primary" bold text={`$${ticker}`} />
             ) : (
               <Tag className="coming-soon-tag">
-                <P3 className="current-color" bold text="Coming Soon" />
+                <P3
+                  className="current-color"
+                  bold
+                  text={
+                    profileType == "waiting_for_approval"
+                      ? "Waiting For Approval"
+                      : "Coming Soon"
+                  }
+                />
               </Tag>
             )}
           </div>

--- a/app/packs/src/components/discovery/discovery_rows.jsx
+++ b/app/packs/src/components/discovery/discovery_rows.jsx
@@ -163,6 +163,7 @@ const DiscoveryRows = ({ discoveryRows, updateFollow }) => {
                       talentLink={`/u/${talent.username}`}
                       marketCap={talent.marketCap}
                       supporterCount={talent.supportersCount}
+                      profileType={talent.profileType}
                     />
                   </div>
                 ))}

--- a/app/packs/src/components/talent/TalentTableCardMode.jsx
+++ b/app/packs/src/components/talent/TalentTableCardMode.jsx
@@ -34,6 +34,7 @@ const TalentTableCardMode = ({
             supporterCount={talent.supportersCount}
             publicPageViewer={publicPageViewer}
             isVerified={talent.isVerified}
+            profileType={talent.user.profileType}
           />
         </div>
       ))}

--- a/app/packs/src/components/talent/TalentTableListMode.jsx
+++ b/app/packs/src/components/talent/TalentTableListMode.jsx
@@ -348,7 +348,15 @@ const TalentTableListMode = ({
                   />
                 ) : (
                   <Tag className="coming-soon-tag ml-2">
-                    <P3 className="current-color" bold text="Coming Soon" />
+                    <P3
+                      className="current-color"
+                      bold
+                      text={
+                        talent.user.profileType == "waiting_for_approval"
+                          ? "Waiting For Approval"
+                          : "Coming Soon"
+                      }
+                    />
                   </Tag>
                 )}
               </div>

--- a/app/views/discovery/index.html.erb
+++ b/app/views/discovery/index.html.erb
@@ -20,6 +20,7 @@
             username: talent["user"]["username"],
             userId: talent["user_id"],
             supportersCount: talent["supporters_count"],
+            profileType: talent["user"]["profile_type"],
           }}
         }},
         marketingArticles: @marketing_articles.map { |article| {

--- a/app/views/talent/index.html.erb
+++ b/app/views/talent/index.html.erb
@@ -17,7 +17,8 @@
               },
               user: {
                 username: talent["user"]["username"],
-                name: talent["user"]["display_name"] || talent["user"]["username"]
+                name: talent["user"]["display_name"] || talent["user"]["username"],
+                profileType: talent["user"]["profile_type"]
               },
               isFollowing: talent['is_following'],
               userId: talent["user_id"],


### PR DESCRIPTION
## Summary

This PR replaces the `Coming Soon` tag from profiles/talents waiting for approval from the admin with the `Waiting For Approval` tag.

## Notion link

https://www.notion.so/talentprotocol/Remove-coming-soon-tag-from-profiles-that-aren-t-approved-a1efd735cecc4ff3891d1d2b691a6b6a
