### PR TITLE
Add whitelist for Talent Mates on persona verification

### DIFF
--- a/app/services/tasks/update.rb
+++ b/app/services/tasks/update.rb
@@ -32,6 +32,8 @@ module Tasks
     def give_rewards_for_task(type:, user:)
       if type == "Tasks::Watchlist"
         user.invites.where(talent_invite: false).update_all(max_uses: nil)
+      elsif type == "Tasks::Verified"
+        WhitelistUserJob.perform_later(user_id: user.id, level: "verified")
       elsif type == "Quests::VerifiedProfile"
         WhitelistUserJob.perform_later(user_id: user.id, level: "verified")
       elsif type == "Quests::TalentProfile"


### PR DESCRIPTION
## Summary

When the persona webhook is called, the update of the Task is called instead of the Quest.