### PR TITLE
Add rescues to the graph API calls

### DIFF
--- a/app/services/talents/refresh_supporters.rb
+++ b/app/services/talents/refresh_supporters.rb
@@ -13,6 +13,9 @@ module Talents
       fetched_supporters_count = 0
 
       talent_supporters_response = talent_supporters(offset: fetched_supporters_count)
+
+      return if talent_supporters_response.blank?
+
       supporters_count = talent_supporters_response.talent_token.supporter_counter.to_i
       total_supply = talent_supporters_response.talent_token.total_supply
       token_day_data = talent_supporters_response.talent_token.token_day_data
@@ -42,6 +45,9 @@ module Talents
         offset: offset,
         variance_start_date: variance_start_date
       )
+    rescue NameError => error
+      Rollbar.error(error, "Unable to find TheGraph client for chain_id: #{talent_token.chain_id}")
+      {}
     end
 
     def variance_start_date

--- a/config/initializers/the_graph_api.rb
+++ b/config/initializers/the_graph_api.rb
@@ -17,9 +17,17 @@ module TheGraphAPI
       end
     end
 
-    Schema = GraphQL::Client.load_schema(HTTP)
+    begin
+      Schema = GraphQL::Client.load_schema(HTTP)
 
-    Client = GraphQL::Client.new(schema: Schema, execute: HTTP)
+      Client = GraphQL::Client.new(schema: Schema, execute: HTTP)
+    rescue KeyError => error
+      # This is a hack to get around the fact that the Celo subgraph is not available
+      puts "Error loading Celo subgraph schema"
+      Rollbar.error(
+        error, "Error loading Celo subgraph schema"
+      )
+    end
   end
 
   module Alfajores
@@ -29,9 +37,17 @@ module TheGraphAPI
       end
     end
 
-    Schema = GraphQL::Client.load_schema(HTTP)
+    begin
+      Schema = GraphQL::Client.load_schema(HTTP)
 
-    Client = GraphQL::Client.new(schema: Schema, execute: HTTP)
+      Client = GraphQL::Client.new(schema: Schema, execute: HTTP)
+    rescue KeyError => error
+      # This is a hack to get around the fact that the Alfajores subgraph is not available
+      puts "Error loading Alfajores subgraph schema"
+      Rollbar.error(
+        error, "Error loading Alfajores subgraph schema"
+      )
+    end
   end
 
   module Mumbai
@@ -41,9 +57,17 @@ module TheGraphAPI
       end
     end
 
-    Schema = GraphQL::Client.load_schema(HTTP)
+    begin
+      Schema = GraphQL::Client.load_schema(HTTP)
 
-    Client = GraphQL::Client.new(schema: Schema, execute: HTTP)
+      Client = GraphQL::Client.new(schema: Schema, execute: HTTP)
+    rescue KeyError => error
+      # This is a hack to get around the fact that the Mumbai subgraph is not available
+      puts "Error loading Mumbai subgraph schema"
+      Rollbar.error(
+        error, "Error loading Mumbai subgraph schema"
+      )
+    end
   end
 
   module Polygon
@@ -53,8 +77,16 @@ module TheGraphAPI
       end
     end
 
-    Schema = GraphQL::Client.load_schema(HTTP)
+    begin
+      Schema = GraphQL::Client.load_schema(HTTP)
 
-    Client = GraphQL::Client.new(schema: Schema, execute: HTTP)
+      Client = GraphQL::Client.new(schema: Schema, execute: HTTP)
+    rescue KeyError => error
+      # This is a hack to get around the fact that the Polygon subgraph is not available
+      puts "Error loading Polygon subgraph schema"
+      Rollbar.error(
+        error, "Error loading Polygon subgraph schema"
+      )
+    end
   end
 end

--- a/lib/the_graph/alfajores/client.rb
+++ b/lib/the_graph/alfajores/client.rb
@@ -4,7 +4,11 @@ module TheGraph
   module Alfajores
     MAX_RECORDS = 100
 
-    TALENT_SUPPORTERS = ::TheGraphAPI::Alfajores::Client.parse TheGraph::Queries::TALENT_SUPPORTERS_QUERY
+    begin
+      TALENT_SUPPORTERS = ::TheGraphAPI::Alfajores::Client.parse TheGraph::Queries::TALENT_SUPPORTERS_QUERY
+    rescue NameError => error
+      Rollbar.error(error, "TheGraph client for Alfajores is down")
+    end
 
     class Client
       class Error < StandardError; end

--- a/lib/the_graph/celo/client.rb
+++ b/lib/the_graph/celo/client.rb
@@ -4,7 +4,11 @@ module TheGraph
   module Celo
     MAX_RECORDS = 100
 
-    TALENT_SUPPORTERS = ::TheGraphAPI::Celo::Client.parse TheGraph::Queries::TALENT_SUPPORTERS_QUERY
+    begin
+      TALENT_SUPPORTERS = ::TheGraphAPI::Celo::Client.parse TheGraph::Queries::TALENT_SUPPORTERS_QUERY
+    rescue NameError => error
+      Rollbar.error(error, "TheGraph client for celo is down")
+    end
 
     class Client
       class Error < StandardError; end

--- a/lib/the_graph/mumbai/client.rb
+++ b/lib/the_graph/mumbai/client.rb
@@ -4,7 +4,11 @@ module TheGraph
   module Mumbai
     MAX_RECORDS = 100
 
-    TALENT_SUPPORTERS = ::TheGraphAPI::Mumbai::Client.parse TheGraph::Queries::TALENT_SUPPORTERS_QUERY
+    begin
+      TALENT_SUPPORTERS = ::TheGraphAPI::Mumbai::Client.parse TheGraph::Queries::TALENT_SUPPORTERS_QUERY
+    rescue NameError => error
+      Rollbar.error(error, "TheGraph client for Mumbai is down")
+    end
 
     class Client
       class Error < StandardError; end

--- a/lib/the_graph/polygon/client.rb
+++ b/lib/the_graph/polygon/client.rb
@@ -4,7 +4,11 @@ module TheGraph
   module Polygon
     MAX_RECORDS = 100
 
-    TALENT_SUPPORTERS = ::TheGraphAPI::Polygon::Client.parse TheGraph::Queries::TALENT_SUPPORTERS_QUERY
+    begin
+      TALENT_SUPPORTERS = ::TheGraphAPI::Polygon::Client.parse TheGraph::Queries::TALENT_SUPPORTERS_QUERY
+    rescue NameError => error
+      Rollbar.error(error, "TheGraph client for Polygon is down")
+    end
 
     class Client
       class Error < StandardError; end


### PR DESCRIPTION
## Summary

When rails boots up, it makes calls to TheGraph in order to load up the schema. This prevents the app from booting up