### PR TITLE
Update confirm_email copy and reduce font

### DIFF
--- a/app/packs/src/components-v2/sign-up-flow/steps/confirm-email/index.jsx
+++ b/app/packs/src/components-v2/sign-up-flow/steps/confirm-email/index.jsx
@@ -79,8 +79,8 @@ export const ConfirmEmailStep = ({ user, goToFirstStep, setHasCreateAccountError
     )) || (
       <Container>
         <TitleRow>
-          <Typography specs={{ variant: "h3", type: "bold" }} color="primary01">
-            Lastly, Please check you inbox and confirm your email:
+          <Typography specs={{ variant: "h5", type: "bold" }} color="primary01">
+          Please go to your inbox to confirm your email address. Check your spam folder if you can't find the email.
           </Typography>
           <Typography specs={{ variant: "p2", type: "regular" }} color="primary03">
             {user.email}


### PR DESCRIPTION
## Summary

Updated the copy on the sign-up-flow, confirm_email step according to the ticket.
Reduced the font from h3 to h5. Screenshots provided of h4 and h5 and I went with the h5 due to better in line distribution of words:

h4 version: https://ibb.co/tD7M0p7
h5 version: https://ibb.co/gb0SvG5

## Notion link

https://www.notion.so/Typo-on-Confirm-Email-fac88c29fc0640fabc42989a87366881

## How to test?

Provided screenshots or running it with the changes.

## Notes

I can change it to another font size if needed.
