### PR TITLE
Fix browser back button behaviour in the sign-up-flow

### DIFF
--- a/app/packs/src/components-v2/sign-up-flow/index.jsx
+++ b/app/packs/src/components-v2/sign-up-flow/index.jsx
@@ -94,6 +94,16 @@ export const SignUpFlow = props => {
     window.history.pushState({}, document.title, urlWithPath);
   }, [stepsState.currentStep]);
 
+  useEffect(() => {
+    const handleBrowserBackButton = () => {
+      stepsState.previousStep();
+    };
+    window.addEventListener('popstate', handleBrowserBackButton);
+    return () => {
+      window.removeEventListener('popstate', handleBrowserBackButton);
+    };
+  }, [stepsState]);
+
   const MemoizedStep = useMemo(
     () => (
       <StepScreen


### PR DESCRIPTION
## Summary

Added a useEffect to mimic the behaviour of the back button present in the MemoizedDefaultFooter if the user pressed the browser's native back button. This way the user can navigate back on the sign-up flow through the browser's back button.

## Notion link

https://talentprotocol.notion.site/Using-browser-back-button-doesn-t-go-back-on-sign-up-flow-55e9a1f23ad14699b0cd1abe021f4fcf

## How to test?

Run the web-dapp, do the new sign up flow and press the Back button in the browser.

## Notes

Short video of the feature working:
https://github.com/talentprotocol/web-dapp/assets/61509756/84bca09a-6083-49e3-9ef7-b80ff1e82de7


