### PR TITLE
Fix career needs naming

### DIFF
--- a/app/models/career_need.rb
+++ b/app/models/career_need.rb
@@ -5,8 +5,8 @@ class CareerNeed < ApplicationRecord
 
   ROLE_NEEDS = [
     "Freelancing or contract roles",
-    "Full-time Roles",
-    "Part-time Roles"
+    "Full-time roles",
+    "Part-time roles"
   ].freeze
 
   belongs_to :career_goal

--- a/app/packs/src/utils/constants.js
+++ b/app/packs/src/utils/constants.js
@@ -56,8 +56,8 @@ export const ERROR_MESSAGES = {
 // This list and order is used to present in the onboarding flow by different categories
 // make sure to check app/packs/src/components/onboarding/OpenTo.jsx after making changes
 export const CAREER_NEEDS_OPTIONS = [
-  "Full-time Roles",
-  "Part-time Roles",
+  "Full-time roles",
+  "Part-time roles",
   "Freelancing or contract roles",
   "Internships",
   "Volunteering for impact projects",


### PR DESCRIPTION
## Summary

<!--- Summarize the changes made to the platform. (Include screenshoots if applicable) -->
<!--- Try to answer the following three questions: What, why and how it changed? -->

## Notion link

<!--- Link to the Notion task. -->

## How to test?

<!--- instructions on how to test the changes. -->

## Notes

Need to run in console:
```rb
CareerNeed.where(title: "Full-time Roles").update_all(title: "Full-time roles")
CareerNeed.where(title: "Part-time Roles").update_all(title: "Part-time roles")
```
