### PR TITLE
Fix i am open to activity

### DIFF
--- a/app/services/career_needs/upsert.rb
+++ b/app/services/career_needs/upsert.rb
@@ -8,12 +8,14 @@ module CareerNeeds
     end
 
     def call
+      return if titles.sort == career_goal.career_needs.pluck(:title).sort
+
       CareerNeed.transaction do
         destroy_career_needs
         upsert_career_needs
       end
 
-      create_activity
+      create_activity if career_goal.career_needs.reload.size.positive?
     end
 
     private

--- a/app/services/users/create.rb
+++ b/app/services/users/create.rb
@@ -99,7 +99,10 @@ module Users
         tag = Tag.find_or_create_by(description: description.downcase)
         UserTag.find_or_create_by!(user: user, tag: tag)
       end
-      CareerNeeds::Upsert.new(career_goal: talent.career_goal, titles: params[:career_needs]).call
+
+      if params[:career_needs]&.length&.positive?
+        CareerNeeds::Upsert.new(career_goal: talent.career_goal, titles: params[:career_needs]).call
+      end
     end
 
     def create_talent_token(user)

--- a/spec/services/career_needs/upsert_spec.rb
+++ b/spec/services/career_needs/upsert_spec.rb
@@ -63,5 +63,22 @@ RSpec.describe CareerNeeds::Upsert do
         end
       end
     end
+
+    context "when all career needs are deleted" do
+      let(:titles) { [] }
+      let!(:career_need) do
+        create :career_need, career_goal: career_goal, title: "Internships"
+      end
+
+      it "enqueues the job to update the career needs update activity" do
+        Sidekiq::Testing.inline! do
+          subject.call
+
+          job = enqueued_jobs.find { |j| j["job_class"] == "ActivityIngestJob" }
+
+          expect(job).to eq nil
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary
 Currently we're creating an activity even when the user deletes all career needs
We only want to create an activity when there's a career need change

## Notion link

<!--- Link to the Notion task. -->

## How to test?

<!--- instructions on how to test the changes. -->

## Notes

<!--- Notes you might consider worth adding. -->
