### PR TITLE
Remove mandatory career goal from relationships

### DIFF
--- a/app/models/career_need.rb
+++ b/app/models/career_need.rb
@@ -1,5 +1,5 @@
 class CareerNeed < ApplicationRecord
-  belongs_to :career_goal
+  belongs_to :career_goal, optional: true
 
   HIRING_NEEDS = ["Finding and hiring talent"].freeze
   ROLE_NEEDS = [

--- a/app/models/goal.rb
+++ b/app/models/goal.rb
@@ -1,7 +1,7 @@
 class Goal < ApplicationRecord
   has_paper_trail
 
-  belongs_to :career_goal
+  belongs_to :career_goal, optional: true
   # TODO: Make it mandatory
   belongs_to :user, optional: true
 

--- a/db/migrate/20230911110223_change_column_null_for_career_goals_relations.rb
+++ b/db/migrate/20230911110223_change_column_null_for_career_goals_relations.rb
@@ -1,0 +1,6 @@
+class ChangeColumnNullForCareerGoalsRelations < ActiveRecord::Migration[7.0]
+  def change
+    change_column_null :goals, :career_goal_id, true
+    change_column_null :career_needs, :career_goal_id, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_08_133614) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_11_110223) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"
@@ -143,7 +143,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_08_133614) do
 
   create_table "career_needs", force: :cascade do |t|
     t.string "title", null: false
-    t.bigint "career_goal_id", null: false
+    t.bigint "career_goal_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["career_goal_id"], name: "index_career_needs_on_career_goal_id"


### PR DESCRIPTION
## Summary

This PR removes the mandatory need of a `career_goal_id` in goals and career_needs. 

This is just a preparatory PR. We won't delete any data yet. In the next PR I will remove any usage of the `career_goal_id` from the app.

## Notion link

https://www.notion.so/talentprotocol/Write-Goal-Flow-V1-0-Dev-MVP-ed08131c7caa4dd39309aef570b536ba?pvs=4#41d729b0325a4a0b812a0a4664d27e61

## How to test?

<!--- instructions on how to test the changes. -->

## Notes

<!--- Notes you might consider worth adding. -->
